### PR TITLE
Use stable BusyBox and upgrade to PostgreSQL 16

### DIFF
--- a/n8n-deployment.yaml
+++ b/n8n-deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       initContainers:
         - name: volume-permissions
-          image: busybox:1.36
+          image: busybox:stable
           command: ["sh", "-c", "chown 1000:1000 /data"]
           volumeMounts:
             - name: n8n-claim0

--- a/postgres-deployment.yaml
+++ b/postgres-deployment.yaml
@@ -21,7 +21,7 @@ spec:
         service: postgres-n8n
     spec:
       containers:
-        - image: postgres:11
+        - image: postgres:16
           name: postgres
           resources:
             limits:


### PR DESCRIPTION
Switch to the stable version of BusyBox for improved reliability and upgrade PostgreSQL to version 16 for enhanced features and performance.