### PR TITLE
Fix Redis deployment fsGroup location

### DIFF
--- a/redis.yaml
+++ b/redis.yaml
@@ -14,6 +14,10 @@ spec:
       labels:
         app: redis
     spec:
+      securityContext:
+        runAsUser: 999
+        runAsGroup: 1000
+        fsGroup: 1000
       containers:
         - name: redis
           image: redis:8-alpine
@@ -24,10 +28,6 @@ spec:
               port: 6379
             initialDelaySeconds: 30
             periodSeconds: 10
-          securityContext:
-            runAsUser: 999
-            runAsGroup: 1000
-            fsGroup: 1000
           resources:
             requests:
               memory: "512Mi"


### PR DESCRIPTION
## Summary
- fix redis deployment by moving fsGroup to pod-level security context

## Testing
- `shellcheck deploy-eks-fargate.sh destroy-eks-fargate.sh upgrade-n8n.sh`

------
https://chatgpt.com/codex/tasks/task_e_685bd47c5fa8832b8f5a724d0bb644a1